### PR TITLE
fix: setting route domain to X.Y.${CLUSTER_INGRESS}

### DIFF
--- a/deploy/core_test.go
+++ b/deploy/core_test.go
@@ -21,6 +21,7 @@ package deploy
 
 import (
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"go.uber.org/zap/zapcore"
@@ -47,6 +48,27 @@ func TestDryRun(t *testing.T) {
 	err := HelmDeploySimulationToolkit(pathChart, &x, "vv-playground", true)
 	if err != nil {
 		t.Fatal("Unable to install/upgrade helm due to", err)
+	}
+}
+
+func TestRegeDiscoverUnpatchedObject(t *testing.T) {
+	r := regexp.MustCompile(PATTERN_FAILED_TO_PATCH)
+	msg := "unable to deploy release st4sd-namespaced-managed: cannot patch \"st4sd-authentication\" " +
+		"with kind Route: Route.route.openshift.io \"st4sd-authentication\" is invalid: spec.host: " +
+		"Invalid value: \"www.st4sd.ibm\": field is immutable"
+
+	s := r.FindStringSubmatch(msg)
+
+	if len(s) != 3 {
+		t.Fatalf("Expected exactly 3 groups but got %d: +%v", len(s), s)
+	}
+
+	if s[1] != "st4sd-authentication" {
+		t.Fatalf("Expected object st4sd-authentication but got \"%s\"", s[1])
+	}
+
+	if s[2] != "Route" {
+		t.Fatalf("Expected kind Route but got \"%s\"", s[2])
 	}
 }
 

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-export VERSION="0.0.12"
-export OLD_VERSION="0.0.11"
+export VERSION="0.0.13"
+export OLD_VERSION="0.0.12"
 
 # VV: All versions that go in the "stable" channel, version[i+1] replaces version[i]
-STABLE_VERSIONS=("0.0.1" "0.0.2" "0.0.3" "0.0.4" "0.0.5" "0.0.6" "0.0.7" "0.0.8" "0.0.9" "0.0.10" "0.0.11" "0.0.12")
+STABLE_VERSIONS=(
+    "0.0.1" "0.0.2" "0.0.3" "0.0.4" "0.0.5" "0.0.6" "0.0.7" 
+    "0.0.8" "0.0.9" "0.0.10" "0.0.11" "0.0.12" "0.0.13")


### PR DESCRIPTION
## Context

Fixes #6 

## Change list

- Propagates the routePrefix value to the st4sd-namespaced-unmanaged helm release so that the `st4sd-runtime-service` ConfigMap is properly configured
- Detects when helm is unable to patch Route objects. In this scenario it deletes and retries the release

## Checklist

- [x] This PR is associated to one (or more) issues that are open
- [x] I have signed off my commits (using `git commit -s`)
- [x] I agree with the ST4SD Code of Conduct
